### PR TITLE
Feat: allow hidden toc items

### DIFF
--- a/__tests__/__snapshots__/extract-toc-test.js.snap
+++ b/__tests__/__snapshots__/extract-toc-test.js.snap
@@ -161,15 +161,35 @@ Object {
     },
   },
   "byManifestId": Object {
-    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": "121",
-    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": "113",
-    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": "119",
-    "item-data-uuid-5b23866eff924613af22d8a296c61653": "118",
-    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": "123",
-    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": "117",
-    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": "120",
-    "item-data-uuid-d17e58059b0542f1a831de1593127652": "122",
-    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": "115",
+    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": Array [
+      "121",
+    ],
+    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": Array [
+      "114",
+      "113",
+    ],
+    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": Array [
+      "119",
+    ],
+    "item-data-uuid-5b23866eff924613af22d8a296c61653": Array [
+      "118",
+    ],
+    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": Array [
+      "123",
+    ],
+    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": Array [
+      "117",
+    ],
+    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": Array [
+      "120",
+    ],
+    "item-data-uuid-d17e58059b0542f1a831de1593127652": Array [
+      "122",
+    ],
+    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": Array [
+      "116",
+      "115",
+    ],
   },
   "items": Array [
     "114",
@@ -183,6 +203,7 @@ Object {
     "122",
     "123",
     "115",
+    "__root__",
   ],
 }
 `;
@@ -350,15 +371,35 @@ Object {
     },
   },
   "byManifestId": Object {
-    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": "143",
-    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": "135",
-    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": "141",
-    "item-data-uuid-5b23866eff924613af22d8a296c61653": "140",
-    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": "145",
-    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": "139",
-    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": "142",
-    "item-data-uuid-d17e58059b0542f1a831de1593127652": "144",
-    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": "137",
+    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": Array [
+      "143",
+    ],
+    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": Array [
+      "136",
+      "135",
+    ],
+    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": Array [
+      "141",
+    ],
+    "item-data-uuid-5b23866eff924613af22d8a296c61653": Array [
+      "140",
+    ],
+    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": Array [
+      "145",
+    ],
+    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": Array [
+      "139",
+    ],
+    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": Array [
+      "142",
+    ],
+    "item-data-uuid-d17e58059b0542f1a831de1593127652": Array [
+      "144",
+    ],
+    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": Array [
+      "138",
+      "137",
+    ],
   },
   "items": Array [
     "136",
@@ -372,6 +413,7 @@ Object {
     "144",
     "145",
     "137",
+    "__root__",
   ],
 }
 `;
@@ -539,15 +581,35 @@ Object {
     },
   },
   "byManifestId": Object {
-    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": "132",
-    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": "124",
-    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": "130",
-    "item-data-uuid-5b23866eff924613af22d8a296c61653": "129",
-    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": "134",
-    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": "128",
-    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": "131",
-    "item-data-uuid-d17e58059b0542f1a831de1593127652": "133",
-    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": "126",
+    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": Array [
+      "132",
+    ],
+    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": Array [
+      "125",
+      "124",
+    ],
+    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": Array [
+      "130",
+    ],
+    "item-data-uuid-5b23866eff924613af22d8a296c61653": Array [
+      "129",
+    ],
+    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": Array [
+      "134",
+    ],
+    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": Array [
+      "128",
+    ],
+    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": Array [
+      "131",
+    ],
+    "item-data-uuid-d17e58059b0542f1a831de1593127652": Array [
+      "133",
+    ],
+    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": Array [
+      "127",
+      "126",
+    ],
   },
   "items": Array [
     "125",
@@ -561,6 +623,7 @@ Object {
     "133",
     "134",
     "126",
+    "__root__",
   ],
 }
 `;
@@ -610,11 +673,15 @@ Object {
     },
   },
   "byManifestId": Object {
-    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": "146",
+    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": Array [
+      "147",
+      "146",
+    ],
   },
   "items": Array [
     "147",
     "146",
+    "__root__",
   ],
 }
 `;
@@ -1372,55 +1439,160 @@ Object {
     },
   },
   "byManifestId": Object {
-    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": "65",
-    "item-data-uuid-0cf7f56918514bb784e1de2b5e739da1": "75",
-    "item-data-uuid-0f371090c0e84cd09a06f868c3fe8efd": "88",
-    "item-data-uuid-0f7b7bf0ed1b4c5c88b86bf81c8e2f92": "94",
-    "item-data-uuid-101710cd602a4fcfa90108c5c0347df7": "103",
-    "item-data-uuid-107c288bb253478f8a3094fdd57e00d0": "73",
-    "item-data-uuid-14c6d82a58e64980992078f1726dac96": "82",
-    "item-data-uuid-1695c0869dbf4fc38e255f1d8571b4e5": "110",
-    "item-data-uuid-17a19334765e441d848dd98a07d3b583": "86",
-    "item-data-uuid-3a07ddda3070483e99e2b20349853c76": "107",
-    "item-data-uuid-3a5daf183fc34c31822a2b16d13a57ba": "97",
-    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": "57",
-    "item-data-uuid-3c0bb8315ea14a2bac12ace68240caff": "76",
-    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": "63",
-    "item-data-uuid-445da3f24e8d49d897c41c17a615bcef": "99",
-    "item-data-uuid-47a9d3e21464491cb37d718162b9b520": "72",
-    "item-data-uuid-553be8a225384235b06f21698e403a16": "89",
-    "item-data-uuid-589d9984380e4568b1eb5710e6e81ca2": "109",
-    "item-data-uuid-5adbebda98604da48e98180467c64cfd": "68",
-    "item-data-uuid-5b23866eff924613af22d8a296c61653": "62",
-    "item-data-uuid-601228182dbc40e2ba71787be4c05654": "92",
-    "item-data-uuid-61380725c0dd484593df2807e84cf853": "98",
-    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": "67",
-    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": "61",
-    "item-data-uuid-74687195b0fb413bba6b9ca5d8aa3cec": "100",
-    "item-data-uuid-757f293b2be647deaa1c5291da00413e": "101",
-    "item-data-uuid-7841571fa25b470fa9b4158ce0544f87": "111",
-    "item-data-uuid-7bf20da5723c4a5799c86f97c2fd81b3": "71",
-    "item-data-uuid-8fc059832a1f4c64be19490536ebc955": "104",
-    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": "64",
-    "item-data-uuid-9a306d7babff42c084fa63ad29079c97": "70",
-    "item-data-uuid-a4f73db0c4ff4464afdbdef6540a1feb": "77",
-    "item-data-uuid-ad4d37cb6ecb4c11ada0eafc3c44146f": "95",
-    "item-data-uuid-bda8bcd0fdaa4c26be8914772d6c84ec": "108",
-    "item-data-uuid-cc1ee917649f4f55855784812d45ef9d": "106",
-    "item-data-uuid-cc3d8d64c26046bc92151bfe70170c4c": "90",
-    "item-data-uuid-d11317bd1e344490a568604ca1f4616f": "93",
-    "item-data-uuid-d15b805965d14521aeb48d93d168b65f": "74",
-    "item-data-uuid-d17e58059b0542f1a831de1593127652": "66",
-    "item-data-uuid-d1dc38f40de742b5a24353c05ed1a23e": "84",
-    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": "59",
-    "item-data-uuid-d43a2540b0774b5f973c841873a8b814": "81",
-    "item-data-uuid-debfcf17707946f0bf220b7924adaa48": "83",
-    "item-data-uuid-e8573f88150047078fdb5bfb083ca5c7": "91",
-    "item-data-uuid-ea0242f6d23d4e608c7252ad571882f5": "85",
-    "item-data-uuid-ec172a4c778d409da1aec2f5474cc337": "112",
-    "item-data-uuid-f7923d60c5894cc999346a9f2c8f5ae7": "102",
-    "item-data-uuid-fb124defa1ef4c04a4f79397ae047df0": "80",
-    "item-data-uuid-ffc2e9c0ab5a404980a1c2686659ab6f": "79",
+    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": Array [
+      "65",
+    ],
+    "item-data-uuid-0cf7f56918514bb784e1de2b5e739da1": Array [
+      "75",
+    ],
+    "item-data-uuid-0f371090c0e84cd09a06f868c3fe8efd": Array [
+      "88",
+    ],
+    "item-data-uuid-0f7b7bf0ed1b4c5c88b86bf81c8e2f92": Array [
+      "94",
+    ],
+    "item-data-uuid-101710cd602a4fcfa90108c5c0347df7": Array [
+      "103",
+    ],
+    "item-data-uuid-107c288bb253478f8a3094fdd57e00d0": Array [
+      "73",
+    ],
+    "item-data-uuid-14c6d82a58e64980992078f1726dac96": Array [
+      "82",
+    ],
+    "item-data-uuid-1695c0869dbf4fc38e255f1d8571b4e5": Array [
+      "110",
+    ],
+    "item-data-uuid-17a19334765e441d848dd98a07d3b583": Array [
+      "87",
+      "86",
+    ],
+    "item-data-uuid-3a07ddda3070483e99e2b20349853c76": Array [
+      "107",
+    ],
+    "item-data-uuid-3a5daf183fc34c31822a2b16d13a57ba": Array [
+      "97",
+    ],
+    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": Array [
+      "58",
+      "57",
+    ],
+    "item-data-uuid-3c0bb8315ea14a2bac12ace68240caff": Array [
+      "76",
+    ],
+    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": Array [
+      "63",
+    ],
+    "item-data-uuid-445da3f24e8d49d897c41c17a615bcef": Array [
+      "99",
+    ],
+    "item-data-uuid-47a9d3e21464491cb37d718162b9b520": Array [
+      "72",
+    ],
+    "item-data-uuid-553be8a225384235b06f21698e403a16": Array [
+      "89",
+    ],
+    "item-data-uuid-589d9984380e4568b1eb5710e6e81ca2": Array [
+      "109",
+    ],
+    "item-data-uuid-5adbebda98604da48e98180467c64cfd": Array [
+      "69",
+      "68",
+    ],
+    "item-data-uuid-5b23866eff924613af22d8a296c61653": Array [
+      "62",
+    ],
+    "item-data-uuid-601228182dbc40e2ba71787be4c05654": Array [
+      "92",
+    ],
+    "item-data-uuid-61380725c0dd484593df2807e84cf853": Array [
+      "98",
+    ],
+    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": Array [
+      "67",
+    ],
+    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": Array [
+      "61",
+    ],
+    "item-data-uuid-74687195b0fb413bba6b9ca5d8aa3cec": Array [
+      "100",
+    ],
+    "item-data-uuid-757f293b2be647deaa1c5291da00413e": Array [
+      "101",
+    ],
+    "item-data-uuid-7841571fa25b470fa9b4158ce0544f87": Array [
+      "111",
+    ],
+    "item-data-uuid-7bf20da5723c4a5799c86f97c2fd81b3": Array [
+      "71",
+    ],
+    "item-data-uuid-8fc059832a1f4c64be19490536ebc955": Array [
+      "105",
+      "104",
+    ],
+    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": Array [
+      "64",
+    ],
+    "item-data-uuid-9a306d7babff42c084fa63ad29079c97": Array [
+      "70",
+    ],
+    "item-data-uuid-a4f73db0c4ff4464afdbdef6540a1feb": Array [
+      "78",
+      "77",
+    ],
+    "item-data-uuid-ad4d37cb6ecb4c11ada0eafc3c44146f": Array [
+      "96",
+      "95",
+    ],
+    "item-data-uuid-bda8bcd0fdaa4c26be8914772d6c84ec": Array [
+      "108",
+    ],
+    "item-data-uuid-cc1ee917649f4f55855784812d45ef9d": Array [
+      "106",
+    ],
+    "item-data-uuid-cc3d8d64c26046bc92151bfe70170c4c": Array [
+      "90",
+    ],
+    "item-data-uuid-d11317bd1e344490a568604ca1f4616f": Array [
+      "93",
+    ],
+    "item-data-uuid-d15b805965d14521aeb48d93d168b65f": Array [
+      "74",
+    ],
+    "item-data-uuid-d17e58059b0542f1a831de1593127652": Array [
+      "66",
+    ],
+    "item-data-uuid-d1dc38f40de742b5a24353c05ed1a23e": Array [
+      "84",
+    ],
+    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": Array [
+      "60",
+      "59",
+    ],
+    "item-data-uuid-d43a2540b0774b5f973c841873a8b814": Array [
+      "81",
+    ],
+    "item-data-uuid-debfcf17707946f0bf220b7924adaa48": Array [
+      "83",
+    ],
+    "item-data-uuid-e8573f88150047078fdb5bfb083ca5c7": Array [
+      "91",
+    ],
+    "item-data-uuid-ea0242f6d23d4e608c7252ad571882f5": Array [
+      "85",
+    ],
+    "item-data-uuid-ec172a4c778d409da1aec2f5474cc337": Array [
+      "112",
+    ],
+    "item-data-uuid-f7923d60c5894cc999346a9f2c8f5ae7": Array [
+      "102",
+    ],
+    "item-data-uuid-fb124defa1ef4c04a4f79397ae047df0": Array [
+      "80",
+    ],
+    "item-data-uuid-ffc2e9c0ab5a404980a1c2686659ab6f": Array [
+      "79",
+    ],
   },
   "items": Array [
     "58",
@@ -1479,6 +1651,7 @@ Object {
     "111",
     "112",
     "104",
+    "__root__",
   ],
 }
 `;
@@ -2236,55 +2409,160 @@ Object {
     },
   },
   "byManifestId": Object {
-    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": "9",
-    "item-data-uuid-0cf7f56918514bb784e1de2b5e739da1": "19",
-    "item-data-uuid-0f371090c0e84cd09a06f868c3fe8efd": "32",
-    "item-data-uuid-0f7b7bf0ed1b4c5c88b86bf81c8e2f92": "38",
-    "item-data-uuid-101710cd602a4fcfa90108c5c0347df7": "47",
-    "item-data-uuid-107c288bb253478f8a3094fdd57e00d0": "17",
-    "item-data-uuid-14c6d82a58e64980992078f1726dac96": "26",
-    "item-data-uuid-1695c0869dbf4fc38e255f1d8571b4e5": "54",
-    "item-data-uuid-17a19334765e441d848dd98a07d3b583": "30",
-    "item-data-uuid-3a07ddda3070483e99e2b20349853c76": "51",
-    "item-data-uuid-3a5daf183fc34c31822a2b16d13a57ba": "41",
-    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": "1",
-    "item-data-uuid-3c0bb8315ea14a2bac12ace68240caff": "20",
-    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": "7",
-    "item-data-uuid-445da3f24e8d49d897c41c17a615bcef": "43",
-    "item-data-uuid-47a9d3e21464491cb37d718162b9b520": "16",
-    "item-data-uuid-553be8a225384235b06f21698e403a16": "33",
-    "item-data-uuid-589d9984380e4568b1eb5710e6e81ca2": "53",
-    "item-data-uuid-5adbebda98604da48e98180467c64cfd": "12",
-    "item-data-uuid-5b23866eff924613af22d8a296c61653": "6",
-    "item-data-uuid-601228182dbc40e2ba71787be4c05654": "36",
-    "item-data-uuid-61380725c0dd484593df2807e84cf853": "42",
-    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": "11",
-    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": "5",
-    "item-data-uuid-74687195b0fb413bba6b9ca5d8aa3cec": "44",
-    "item-data-uuid-757f293b2be647deaa1c5291da00413e": "45",
-    "item-data-uuid-7841571fa25b470fa9b4158ce0544f87": "55",
-    "item-data-uuid-7bf20da5723c4a5799c86f97c2fd81b3": "15",
-    "item-data-uuid-8fc059832a1f4c64be19490536ebc955": "48",
-    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": "8",
-    "item-data-uuid-9a306d7babff42c084fa63ad29079c97": "14",
-    "item-data-uuid-a4f73db0c4ff4464afdbdef6540a1feb": "21",
-    "item-data-uuid-ad4d37cb6ecb4c11ada0eafc3c44146f": "39",
-    "item-data-uuid-bda8bcd0fdaa4c26be8914772d6c84ec": "52",
-    "item-data-uuid-cc1ee917649f4f55855784812d45ef9d": "50",
-    "item-data-uuid-cc3d8d64c26046bc92151bfe70170c4c": "34",
-    "item-data-uuid-d11317bd1e344490a568604ca1f4616f": "37",
-    "item-data-uuid-d15b805965d14521aeb48d93d168b65f": "18",
-    "item-data-uuid-d17e58059b0542f1a831de1593127652": "10",
-    "item-data-uuid-d1dc38f40de742b5a24353c05ed1a23e": "28",
-    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": "3",
-    "item-data-uuid-d43a2540b0774b5f973c841873a8b814": "25",
-    "item-data-uuid-debfcf17707946f0bf220b7924adaa48": "27",
-    "item-data-uuid-e8573f88150047078fdb5bfb083ca5c7": "35",
-    "item-data-uuid-ea0242f6d23d4e608c7252ad571882f5": "29",
-    "item-data-uuid-ec172a4c778d409da1aec2f5474cc337": "56",
-    "item-data-uuid-f7923d60c5894cc999346a9f2c8f5ae7": "46",
-    "item-data-uuid-fb124defa1ef4c04a4f79397ae047df0": "24",
-    "item-data-uuid-ffc2e9c0ab5a404980a1c2686659ab6f": "23",
+    "item-data-uuid-01eee42463c54f1b945502ebf51ab9ab": Array [
+      "9",
+    ],
+    "item-data-uuid-0cf7f56918514bb784e1de2b5e739da1": Array [
+      "19",
+    ],
+    "item-data-uuid-0f371090c0e84cd09a06f868c3fe8efd": Array [
+      "32",
+    ],
+    "item-data-uuid-0f7b7bf0ed1b4c5c88b86bf81c8e2f92": Array [
+      "38",
+    ],
+    "item-data-uuid-101710cd602a4fcfa90108c5c0347df7": Array [
+      "47",
+    ],
+    "item-data-uuid-107c288bb253478f8a3094fdd57e00d0": Array [
+      "17",
+    ],
+    "item-data-uuid-14c6d82a58e64980992078f1726dac96": Array [
+      "26",
+    ],
+    "item-data-uuid-1695c0869dbf4fc38e255f1d8571b4e5": Array [
+      "54",
+    ],
+    "item-data-uuid-17a19334765e441d848dd98a07d3b583": Array [
+      "31",
+      "30",
+    ],
+    "item-data-uuid-3a07ddda3070483e99e2b20349853c76": Array [
+      "51",
+    ],
+    "item-data-uuid-3a5daf183fc34c31822a2b16d13a57ba": Array [
+      "41",
+    ],
+    "item-data-uuid-3b13d68a9f9447fe8bd6f2d7c7ea7403": Array [
+      "2",
+      "1",
+    ],
+    "item-data-uuid-3c0bb8315ea14a2bac12ace68240caff": Array [
+      "20",
+    ],
+    "item-data-uuid-40c45e21a58c438283bf95dcaa809537": Array [
+      "7",
+    ],
+    "item-data-uuid-445da3f24e8d49d897c41c17a615bcef": Array [
+      "43",
+    ],
+    "item-data-uuid-47a9d3e21464491cb37d718162b9b520": Array [
+      "16",
+    ],
+    "item-data-uuid-553be8a225384235b06f21698e403a16": Array [
+      "33",
+    ],
+    "item-data-uuid-589d9984380e4568b1eb5710e6e81ca2": Array [
+      "53",
+    ],
+    "item-data-uuid-5adbebda98604da48e98180467c64cfd": Array [
+      "13",
+      "12",
+    ],
+    "item-data-uuid-5b23866eff924613af22d8a296c61653": Array [
+      "6",
+    ],
+    "item-data-uuid-601228182dbc40e2ba71787be4c05654": Array [
+      "36",
+    ],
+    "item-data-uuid-61380725c0dd484593df2807e84cf853": Array [
+      "42",
+    ],
+    "item-data-uuid-6ad2f32297f84d1da04638f7e582c374": Array [
+      "11",
+    ],
+    "item-data-uuid-6d74e8e547ec455a9c00ebb37cb4a872": Array [
+      "5",
+    ],
+    "item-data-uuid-74687195b0fb413bba6b9ca5d8aa3cec": Array [
+      "44",
+    ],
+    "item-data-uuid-757f293b2be647deaa1c5291da00413e": Array [
+      "45",
+    ],
+    "item-data-uuid-7841571fa25b470fa9b4158ce0544f87": Array [
+      "55",
+    ],
+    "item-data-uuid-7bf20da5723c4a5799c86f97c2fd81b3": Array [
+      "15",
+    ],
+    "item-data-uuid-8fc059832a1f4c64be19490536ebc955": Array [
+      "49",
+      "48",
+    ],
+    "item-data-uuid-999b44bf3f03460cbdf41781bd702168": Array [
+      "8",
+    ],
+    "item-data-uuid-9a306d7babff42c084fa63ad29079c97": Array [
+      "14",
+    ],
+    "item-data-uuid-a4f73db0c4ff4464afdbdef6540a1feb": Array [
+      "22",
+      "21",
+    ],
+    "item-data-uuid-ad4d37cb6ecb4c11ada0eafc3c44146f": Array [
+      "40",
+      "39",
+    ],
+    "item-data-uuid-bda8bcd0fdaa4c26be8914772d6c84ec": Array [
+      "52",
+    ],
+    "item-data-uuid-cc1ee917649f4f55855784812d45ef9d": Array [
+      "50",
+    ],
+    "item-data-uuid-cc3d8d64c26046bc92151bfe70170c4c": Array [
+      "34",
+    ],
+    "item-data-uuid-d11317bd1e344490a568604ca1f4616f": Array [
+      "37",
+    ],
+    "item-data-uuid-d15b805965d14521aeb48d93d168b65f": Array [
+      "18",
+    ],
+    "item-data-uuid-d17e58059b0542f1a831de1593127652": Array [
+      "10",
+    ],
+    "item-data-uuid-d1dc38f40de742b5a24353c05ed1a23e": Array [
+      "28",
+    ],
+    "item-data-uuid-d2a6e8f4db704bae875c9b4c5dc209cc": Array [
+      "4",
+      "3",
+    ],
+    "item-data-uuid-d43a2540b0774b5f973c841873a8b814": Array [
+      "25",
+    ],
+    "item-data-uuid-debfcf17707946f0bf220b7924adaa48": Array [
+      "27",
+    ],
+    "item-data-uuid-e8573f88150047078fdb5bfb083ca5c7": Array [
+      "35",
+    ],
+    "item-data-uuid-ea0242f6d23d4e608c7252ad571882f5": Array [
+      "29",
+    ],
+    "item-data-uuid-ec172a4c778d409da1aec2f5474cc337": Array [
+      "56",
+    ],
+    "item-data-uuid-f7923d60c5894cc999346a9f2c8f5ae7": Array [
+      "46",
+    ],
+    "item-data-uuid-fb124defa1ef4c04a4f79397ae047df0": Array [
+      "24",
+    ],
+    "item-data-uuid-ffc2e9c0ab5a404980a1c2686659ab6f": Array [
+      "23",
+    ],
   },
   "items": Array [
     "2",
@@ -2343,6 +2621,7 @@ Object {
     "55",
     "56",
     "48",
+    "__root__",
   ],
 }
 `;

--- a/extract/toc.js
+++ b/extract/toc.js
@@ -9,8 +9,8 @@ export const ROOT = '__root__';
 
 export default function toc(tocHtml, manifest, spine) {
   const byId = {};
-  const byManifestId = {};
   const items = [];
+  const byManifestId = {};
   const tocRoot = findTocRoot(tocHtml.html.body);
   if (!tocRoot) {
     throw 'The root node of your navigation document (table of contents) could not be found. Please ensure the file contains a nav element with an attribute of epub:type="toc"';
@@ -46,10 +46,15 @@ export default function toc(tocHtml, manifest, spine) {
         }
       }
 
-      if (id !== ROOT) {
-        byManifestId[manifestId] = id;
-        items.push(id);
+      if (manifestId) {
+        if(manifestId in byManifestId) {
+          byManifestId[manifestId].push(id);
+        } else {
+          byManifestId[manifestId] = [id];
+        }
       }
+
+      items.push(id);
 
       byId[id] = {
         childNodes,


### PR DESCRIPTION
Updated to allow byManifestId to have an array of multiple items.

In some cases a manifestId will be shared by two toc items where the items are on two different
levels and the child item is apart of a hidden set of items.

This change makes both items available.